### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ config.sub
 configure
 configure.ac
 depcomp
+doc/
 install-sh
 missing
 mkinstalldirs
@@ -19,3 +20,13 @@ stamp-h
 isns.pot
 autom4te.cache
 *.ami
+testsuite/*.exp
+testsuite/*.log
+testsuite/config/
+testsuite/run/
+testsuite/raw.tmp.*
+testsuite/tmp.err.*
+testsuite/tmp.out.*
+testsuite/yast2-isns.sum
+testsuite/yast2-isns.test/
+.yardoc/


### PR DESCRIPTION
Just to make [Travis](https://travis-ci.org/yast/yast-isns/builds/560974003) happy again :)

```
rake aborted!
New files missing in git (or add them to to .gitignore):
.yardoc/checksums
.yardoc/object_types
.yardoc/objects/root.dat
.yardoc/proxy_types
doc/_index.html
doc/class_list.html
...
```